### PR TITLE
"from_timer" was renamed to "timer_container_of"

### DIFF
--- a/ms912x_transfer.c
+++ b/ms912x_transfer.c
@@ -12,7 +12,7 @@
 
 static void ms912x_request_timeout(struct timer_list *t)
 {
-	struct ms912x_usb_request *request = from_timer(request, t, timer);
+	struct ms912x_usb_request *request = timer_container_of(request, t, timer);
 	usb_sg_cancel(&request->sgr);
 }
 


### PR DESCRIPTION
I am using Arch Linux with Kernel 6.16.4-arch1-1. This patch allows the driver to be compiled. "from_timer" was renamed to "timer_container_of" in the Linux Kernel. There seems to be some graphical problems. Idk how to fix that, so good luck.